### PR TITLE
Fixed $user_criteria->groupId

### DIFF
--- a/brief/BriefPlugin.php
+++ b/brief/BriefPlugin.php
@@ -86,7 +86,7 @@ Class BriefPlugin extends BasePlugin
     			// Criteria is basically a 'return elements that match this'
     			$user_criteria = craft()->elements->getCriteria(ElementType::User);
 
-    			$user_criteria->group_id = $settings->user_group;
+    			$user_criteria->groupId = $settings->user_group;
 
     			$users = $user_criteria->find();
 


### PR DESCRIPTION
The plugin wasn't actually getting users from the particular group as group_id didn't do anything. This resulted in just returning all users, limited to the default 100. Luckily, I had an invalid email in my users so it stopped sending after about 3 emails went out.
